### PR TITLE
Setup cross build & clarify usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ What the DSL *does* provide is the ablity to formulate queries thusly:
 ```scala
   // Using an Untyped.criteria
   {
+  import reactivemongo.extensions.dsl.criteria._
   import Untyped._
 
   // The MongoDB properties referenced are not enforced by the compiler
@@ -45,6 +46,7 @@ Another form which achieves the same result is to use one of the `where` methods
 ```scala
   // Using one of the Untyped.where overloads
   {
+  import reactivemongo.extensions.dsl.criteria._
   import Untyped._
 
   val cursor = collection.find(
@@ -64,6 +66,7 @@ For situations where the MongoDB document structure is well known and a develope
   // Using a Typed criteria which restricts properties to those
   // within a given type and/or those directly accessible
   // through property selectors.
+  import reactivemongo.extensions.dsl.criteria._
   import Typed._
 
   case class Nested (rating : Double)

--- a/project/Criteria.scala
+++ b/project/Criteria.scala
@@ -23,7 +23,8 @@ object BuildSettings
 	val buildSettings = Defaults.defaultSettings ++ Seq(
 		organization := "org.reactivemongo",
 		version := buildVersion,
-		scalaVersion := "2.11.11",
+		scalaVersion := "2.11.12",
+		crossScalaVersions := Seq("2.11.12", "2.12.4"),
 		javaOptions in test ++= Seq("-Xmx512m", "-XX:MaxPermSize=512m"),
 		scalacOptions ++= Seq("-unchecked", "-deprecation"),
 		scalacOptions in (Compile, doc) ++= Seq (
@@ -84,13 +85,13 @@ object Resolvers
 
 object Dependencies
 {
-	val reactiveMongoVersion = "0.12.5"
+	val reactiveMongoVersion = "0.12.7"
 
 	val bson = "org.reactivemongo" %% "reactivemongo-bson" % reactiveMongoVersion
 
 	val bsonmacros = "org.reactivemongo" %% "reactivemongo-bson-macros" % reactiveMongoVersion
 
-    val scalaTest = "org.scalatest" %% "scalatest" % "2.1.5" % "test"
+    val scalaTest = "org.scalatest" %% "scalatest" % "3.0.4" % "test"
 }
 
 object ReactiveMongoCriteriaBuild extends Build


### PR DESCRIPTION
- setup scalaCrossVersions
- add `import reactivemongo.extensions.dsl.criteria._` import to usage example (#2)